### PR TITLE
fix: address code review round 2 (issues #17-#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Transforms a repository into an agent-ready environment through 8 phases:
 |-------|------|
 | 0. Discovery | Detect stack, map architecture, identify layers, inject dynamic context |
 | 1. AGENTS.md | ~100-line orientation map (index, not encyclopedia) |
-| 2. docs/ | System of record: `architecture/LAYERS.md` + `golden-principles/` + `guides/` |
+| 2. docs/ | System of record: `architecture/LAYERS.md` + `golden-principles/` + `SECURITY.md` + `guides/` |
 | 3. Testing | Architecture boundary test with ratchet mechanism |
 | 4. Linting | Import restriction rules with remediation in error messages |
 | 5. CI | Parallel lint + typecheck + test + build pipeline |
@@ -21,14 +21,14 @@ Transforms a repository into an agent-ready environment through 8 phases:
 
 ## Core Principles (from OpenAI)
 
-1. Engineers become environment designers
-2. Give agents a map, not an encyclopedia
-3. If agents can't see it, it doesn't exist
-4. Enforce architecture mechanically, not via markdown
-5. Boring technology wins
-6. Entropy management is garbage collection
-7. Throughput changes merge philosophy
-8. Agent-to-agent code review
+1. Engineers become environment designers — define constraints, not implementations
+2. Give agents a map, not an encyclopedia — AGENTS.md ~100 lines, progressive disclosure
+3. If agents can't see it, it doesn't exist — all knowledge machine-readable in repo
+4. Enforce architecture mechanically, not via markdown — linters and tests, not prose
+5. Boring technology wins — composable, stable, well-trained-on APIs
+6. Entropy management is garbage collection — periodic scans catch drift
+7. Throughput changes merge philosophy — minimal blocking gates
+8. Agent-to-agent code review — humans intervene only for judgment calls
 
 ## Installation
 
@@ -111,6 +111,7 @@ project-root/
 │   │   ├── core-beliefs.md
 │   │   └── {NNNN-title}.md
 │   ├── references/                    # External docs for LLMs              [Recommended]
+│   │   └── {library}-llms.txt
 │   ├── DESIGN.md                      # Design philosophy                   [Recommended]
 │   ├── PLANS.md                       # Exec-plans overview                 [Recommended]
 │   ├── QUALITY_SCORE.md               # Per-domain quality grades           [Recommended]
@@ -118,6 +119,7 @@ project-root/
 │   ├── STACK.md                       # Stack conventions                   [Conditional]
 │   ├── product-specs/                 # Product specs                       [Conditional]
 │   └── generated/                     # Auto-generated docs                 [Conditional]
+│       └── {db-schema,api-spec}.md
 ├── scripts/gc/                        # Garbage collection scripts
 ├── tests/architecture/
 │   └── boundary.test.*                # Mechanical layer enforcement

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,7 +12,7 @@
 |------|------|
 | 0. Discovery | 检测技术栈、映射架构、识别分层、注入动态上下文 |
 | 1. AGENTS.md | ~100 行导向地图（索引，不是百科全书） |
-| 2. docs/ | 单一事实来源：`architecture/LAYERS.md` + `golden-principles/` + `guides/` |
+| 2. docs/ | 单一事实来源：`architecture/LAYERS.md` + `golden-principles/` + `SECURITY.md` + `guides/` |
 | 3. Testing | 架构边界测试 + 棘轮机制（KNOWN_VIOLATIONS 只能缩减） |
 | 4. Linting | 导入限制规则（错误信息内含修复指令） |
 | 5. CI | 并行 lint + typecheck + test + build 流水线 |
@@ -111,6 +111,7 @@ project-root/
 │   │   ├── core-beliefs.md
 │   │   └── {NNNN-title}.md
 │   ├── references/                    # 外部文档（LLM 友好格式）             [推荐]
+│   │   └── {library}-llms.txt
 │   ├── DESIGN.md                      # 设计哲学                             [推荐]
 │   ├── PLANS.md                       # 执行计划概览                          [推荐]
 │   ├── QUALITY_SCORE.md               # 各域质量评分                          [推荐]
@@ -118,6 +119,7 @@ project-root/
 │   ├── STACK.md                       # 技术栈约定                            [条件]
 │   ├── product-specs/                 # 产品规格                              [条件]
 │   └── generated/                     # 自动生成文档                          [条件]
+│       └── {db-schema,api-spec}.md
 ├── scripts/gc/                        # 垃圾回收脚本
 ├── tests/architecture/
 │   └── boundary.test.*                # 机械性层级强制
@@ -171,6 +173,8 @@ project-root/
 | 无安全文档 | docs/SECURITY.md 作为必须项 | 安全上下文对 agent 安全是不可选的 |
 
 ## 上下文策略：静态 vs 动态
+
+本 skill 区分两种类型的上下文：
 
 **静态上下文**（写在 repo 里，随时可读）：
 - `AGENTS.md` — agent 入口索引，~100 行

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,7 @@ AI agents can only work with what they can see. Without structured documentation
 
 <Execution_Policy>
 - Phase 0 (Discovery) is MANDATORY — never skip, never assume the stack
-- **Argument parsing:** `full` = all phases (default). `N` = single phase. `N-M` = phase range. No argument = ask user. Phase 0 always runs regardless of argument.
+- **Argument parsing:** `full` = all phases. `N` = single phase. `N-M` = phase range. No argument = interactive (asks user what to set up). Phase 0 always runs regardless of argument.
 - Read before you write — match existing code style and patterns
 - Use `git mv` for doc restructuring to preserve history
 - New lint rules warn first if pre-existing violations exist — don't break the build
@@ -246,7 +246,7 @@ project-root/
 ## Reference Files
 
 Detailed templates and guides are in `references/` — read on demand per phase:
-- `references/layer-templates.md` — 4 tech stack layer models
+- `references/layer-templates.md` — 5 layer models (4 tech stacks + OpenAI original)
 - `references/agents-md-template.md` — AGENTS.md template
 - `references/context-strategy.md` — Static vs dynamic context tables
 - `references/exec-plan-template.md` — ExecPlan (docs/exec-plans/) standard

--- a/references/agents-md-template.md
+++ b/references/agents-md-template.md
@@ -39,19 +39,26 @@ Dependency flows **downward only**. Never import upward.
 ## Documentation Map
 
 ```
+ARCHITECTURE.md                       Top-level domain map (root)
 docs/
-├── architecture/         Layer rules, dependency graph
-├── guides/               Setup, testing, deployment how-tos
-└── golden-principles/    Canonical patterns (DO/DON'T examples)
+├── architecture/                     Layer rules, dependency graph
+├── golden-principles/                Canonical patterns (DO/DON'T examples)
+├── SECURITY.md                       Auth, secrets, threat model
+├── guides/                           Setup, testing, deployment how-tos
+├── exec-plans/                       Feature implementation plans
+├── design-docs/                      Architecture decision records
+└── references/                       External library docs (LLM-friendly)
 ```
 
 ## Where to Look First
 
-| Task              | Start here           |
-|-------------------|---------------------|
-| {common task 1}   | {directory/file}     |
-| {common task 2}   | {directory/file}     |
-| {common task 3}   | {directory/file}     |
+| Task              | Start here                    |
+|-------------------|-------------------------------|
+| Architecture overview | ARCHITECTURE.md (root)    |
+| Layer rules       | docs/architecture/LAYERS.md   |
+| {common task 1}   | {directory/file}              |
+| {common task 2}   | {directory/file}              |
+| {common task 3}   | {directory/file}              |
 
 ## Constraints (Machine-Readable)
 

--- a/references/boundary-test-template.md
+++ b/references/boundary-test-template.md
@@ -56,20 +56,25 @@ const LAYER_RULES: Record<string, string[]> = {
   pages: ['components', 'services', 'lib', 'types'],
 };
 
-const IMPORT_RE = /import\s+.*\s+from\s+['"]([^'"]+)['"]/g;
+// Matches `from '...'` on any line — handles single-line and multi-line imports,
+// plus re-exports (`export { x } from '...'`).
+// NOTE: This is a simplified scanner. For full accuracy (dynamic imports, require()),
+// use ts-morph or @babel/parser AST parsing (see references/stack-routing.md).
+const FROM_RE = /\bfrom\s+['"]([^'"]+)['"]/;
 
 function getLayer(filePath: string): string | null {
-  for (const layer of Object.keys(LAYER_RULES)) {
-    if (filePath.startsWith(`src/${layer}/`)) return layer;
-  }
+  // Adapt 'src' to your project's source root
+  const match = filePath.match(/^src\/([^/]+)\//);
+  if (match && match[1] in LAYER_RULES) return match[1];
   return null;
 }
 
 function resolveTargetLayer(importPath: string): string | null {
+  // Strip common path aliases (@/, ~/, #/)
+  const normalized = importPath.replace(/^[@~#]\//, '');
+  const segments = normalized.split('/');
   for (const layer of Object.keys(LAYER_RULES)) {
-    if (importPath.includes(`/${layer}/`) || importPath.startsWith(layer)) {
-      return layer;
-    }
+    if (segments.includes(layer)) return layer;
   }
   return null;
 }
@@ -81,9 +86,15 @@ function scanFile(filePath: string): Array<{ file: string; line: number; imports
   const fromLayer = getLayer(relative(process.cwd(), filePath));
   if (!fromLayer) return violations;
 
+  let inTypeImport = false;
   for (let i = 0; i < lines.length; i++) {
-    const matches = lines[i].matchAll(IMPORT_RE);
-    for (const match of matches) {
+    const line = lines[i];
+
+    // Track type-only imports (erased at compile time, not runtime dependencies)
+    if (/^\s*import\s+type\s/.test(line)) inTypeImport = true;
+
+    const match = line.match(FROM_RE);
+    if (match && !inTypeImport) {
       const targetLayer = resolveTargetLayer(match[1]);
       if (targetLayer && !LAYER_RULES[fromLayer].includes(targetLayer) && targetLayer !== fromLayer) {
         violations.push({
@@ -95,6 +106,9 @@ function scanFile(filePath: string): Array<{ file: string; line: number; imports
         });
       }
     }
+
+    // Reset type-import tracking when the from-clause ends the statement
+    if (inTypeImport && FROM_RE.test(line)) inTypeImport = false;
   }
   return violations;
 }
@@ -114,6 +128,7 @@ function collectFiles(dir: string, ext: string[]): string[] {
 }
 
 describe('Architecture Boundary Test', () => {
+  // Adapt 'src' to your project's source root
   const files = collectFiles('src', ['.ts', '.tsx']);
   const allViolations = files.flatMap(scanFile);
 
@@ -125,15 +140,11 @@ describe('Architecture Boundary Test', () => {
       const msg = newViolations
         .map(v => `VIOLATION: ${v.file}:${v.line} imports ${v.imports} — ${v.from_layer} cannot import ${v.to_layer}. See docs/architecture/LAYERS.md`)
         .join('\n');
-      fail(`New architecture violations found:\n${msg}`);
+      throw new Error(`New architecture violations found:\n${msg}`);
     }
   });
 
-  test('known violations only shrink, never grow (ratchet)', () => {
-    const baselineSet = new Set(knownViolations.map(v => `${v.file}:${v.imports}`));
-    const currentSet = new Set(allViolations.map(v => `${v.file}:${v.imports}`));
-    const added = [...currentSet].filter(v => !baselineSet.has(v));
-    expect(added).toEqual([]);
+  test('violation count only shrinks (ratchet)', () => {
     expect(allViolations.length).toBeLessThanOrEqual(knownViolations.length);
   });
 });
@@ -159,17 +170,20 @@ KNOWN_VIOLATIONS_PATH = Path("tests/architecture/known-violations.json")
 
 
 def get_layer(file_path: Path) -> str | None:
+    # Adapt 'src' to your project's source root (e.g., package name, 'app/')
     parts = file_path.parts
-    for layer in LAYER_RULES:
-        if layer in parts:
-            return layer
+    if len(parts) >= 2 and parts[0] == "src" and parts[1] in LAYER_RULES:
+        return parts[1]
     return None
 
 
 def scan_imports(file_path: Path) -> list[dict]:
     violations = []
     source = file_path.read_text()
-    tree = ast.parse(source)
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return violations  # Skip unparseable files
     from_layer = get_layer(file_path)
     if not from_layer:
         return violations
@@ -185,6 +199,7 @@ def scan_imports(file_path: Path) -> list[dict]:
                         "from_layer": from_layer,
                         "to_layer": layer,
                     })
+                break  # Only match the first (shallowest) layer
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -200,6 +215,7 @@ def test_no_new_violations():
     known = json.loads(KNOWN_VIOLATIONS_PATH.read_text()) if KNOWN_VIOLATIONS_PATH.exists() else []
     known_set = {(v["file"], v["imports"]) for v in known}
 
+    # Adapt 'src' to your project's source root (e.g., package name, 'app/')
     all_violations = []
     for py_file in Path("src").rglob("*.py"):
         all_violations.extend(scan_imports(py_file))
@@ -214,20 +230,15 @@ def test_no_new_violations():
 
 def test_ratchet_only_shrinks():
     known = json.loads(KNOWN_VIOLATIONS_PATH.read_text()) if KNOWN_VIOLATIONS_PATH.exists() else []
-    known_set = {(v["file"], v["imports"]) for v in known}
 
+    # Adapt 'src' to your project's source root (e.g., package name, 'app/')
     all_violations = []
     for py_file in Path("src").rglob("*.py"):
         all_violations.extend(scan_imports(py_file))
 
-    current_set = {(v["file"], v["imports"]) for v in all_violations}
-    added = current_set - known_set
-    assert not added, (
-        f"New violations added to baseline: {added}. "
-        "KNOWN_VIOLATIONS can only shrink — fix violations, never add new ones."
-    )
     assert len(all_violations) <= len(known), (
-        f"Violation count increased: {len(all_violations)} > baseline {len(known)}."
+        f"Violation count increased: {len(all_violations)} > baseline {len(known)}. "
+        "Fix violations to reduce the count — never add new ones."
     )
 ```
 

--- a/references/ci-templates.md
+++ b/references/ci-templates.md
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: {setup-action}          # actions/setup-node, actions/setup-python, etc.
+      - uses: {setup-action}          # SHA-pin like checkout — see Action Pinning below
       - run: {install_command}
       - run: {lint_command}
 
@@ -64,9 +64,22 @@ jobs:
 
 **Notes:** Remove `typecheck` job if the stack doesn't have a separate typecheck step (Go, Rust). Remove `build` job if not a packaged/deployed artifact.
 
+### Action Pinning
+
+All `uses:` references MUST be SHA-pinned with a tag comment for auditability. Never use bare tag references (`@v4`) — tags are mutable and vulnerable to supply-chain attacks.
+
+Common setup actions (pin to latest at time of use):
+- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
+- `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`
+- `actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0`
+- `actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1`
+
 ## GitLab CI (.gitlab-ci.yml)
 
 ~~~yaml
+default:
+  image: {runtime-image}  # e.g., node:20, python:3.12, golang:1.22
+
 stages: [lint, typecheck, test, build]
 
 lint:
@@ -149,10 +162,20 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
+            const title = `GC scan found issues — ${new Date().toISOString().slice(0, 10)}`;
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'garbage-collection',
+              state: 'open',
+            });
+            if (existing.some(i => i.title === title)) {
+              return; // Already reported today
+            }
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `GC scan found issues — ${new Date().toISOString().slice(0, 10)}`,
+              title,
               labels: ['garbage-collection'],
               body: 'Weekly GC scan detected entropy. Run the GC command from your Makefile or package.json locally for details.'
             });

--- a/references/security-template.md
+++ b/references/security-template.md
@@ -15,6 +15,10 @@ Use generic descriptions: "Database credentials are loaded from environment vari
 
 ## Template
 
+<!-- AGENT INSTRUCTION: The exclusion rules above apply to ALL sections below.
+     Never include specific environment variable names, credential file paths,
+     internal hostnames/IPs, or unpatched vulnerability details anywhere. -->
+
 ~~~markdown
 # Security
 

--- a/references/stack-routing.md
+++ b/references/stack-routing.md
@@ -23,7 +23,7 @@ Use these tables to select the right tooling for the detected stack. Phase 0 dis
 | Python (Ruff) | ruff | `banned-api` (flake8-tidy-imports) | `pyproject.toml [tool.ruff]` |
 | Python (Flake8) | flake8 | `flake8-import-restrictions` | `.flake8` or `setup.cfg` |
 | Go | golangci-lint | `depguard` | `.golangci.yml` |
-| Rust | clippy | `disallowed_methods` / custom lint | `clippy.toml` |
+| Rust | clippy | `pub(crate)` visibility + workspace deps | `Cargo.toml` + module structure |
 | Java | ArchUnit | `ArchRuleDefinition.noClasses()` | Test file (ArchUnit is test-based) |
 
 **Key rule:** Every linter error MUST include remediation text. Error output IS agent context.
@@ -35,7 +35,7 @@ Use these tables to select the right tooling for the detected stack. Phase 0 dis
 | JS/TS | `eslint .` | `tsc --noEmit` | `jest` / `vitest` | `next build` / `tsc` |
 | Python | `ruff check .` | `mypy .` (if typed) | `pytest` | `python -m build` (if packaged) |
 | Go | `golangci-lint run` | (included in build) | `go test ./...` | `go build ./...` |
-| Rust | `clippy` | (included in build) | `cargo test` | `cargo build --release` |
+| Rust | `cargo clippy` | (included in build) | `cargo test` | `cargo build --release` |
 | Java/Kotlin | `checkstyle` / `ktlint` | (compiled language) | `./gradlew test` | `./gradlew build` |
 
 **Not every stack needs all 4 jobs.** Go and Rust combine typecheck with build. Python may skip build if not a published package. Read `references/ci-templates.md` for starter YAML.


### PR DESCRIPTION
## Summary

Fixes all issues found during pre-launch code review of the harness-init skill.

- **#17 (CRITICAL):** TypeScript boundary test — fixed regex to handle multi-line imports, `import type` filtering, `resolveTargetLayer` false matches, replaced non-existent `fail()` API
- **#18 (CRITICAL):** Python boundary test — fixed `get_layer()` wrong-layer match, `_check_target` multi-violation inflation, `ast.parse` crash on syntax errors
- **#19 (HIGH):** CI templates — added Action Pinning section with SHA examples, GitLab `image:` directive, GC issue deduplication logic, fixed `clippy` → `cargo clippy`
- **#20 (HIGH):** AGENTS.md template — expanded Documentation Map with SECURITY.md/exec-plans/design-docs/references, added ARCHITECTURE.md reference, fixed layer model count
- **#21 (HIGH):** Stack routing — corrected Rust Phase 4 linter entry from `disallowed_methods` to `pub(crate)` visibility
- **#22 (MEDIUM):** Cross-document consistency — Phase 2 descriptions, file tree children, EN/CN parity, argument-hint wording, security template global exclusion note

Closes #17, closes #18, closes #19, closes #20, closes #21, closes #22

## Files Changed (8)

| File | Changes |
|------|---------|
| `references/boundary-test-template.md` | TS + Python skeleton fixes |
| `references/ci-templates.md` | Action Pinning, GitLab image, GC dedup |
| `references/stack-routing.md` | Rust entries corrected |
| `references/agents-md-template.md` | Documentation Map expanded |
| `references/security-template.md` | Global exclusion note |
| `SKILL.md` | Layer model count, argument-hint wording |
| `README.md` | Phase 2 desc, file tree, Core Principles |
| `README_CN.md` | Phase 2 desc, file tree, Context Strategy intro |

## Test plan

- [ ] Verify TypeScript boundary test skeleton compiles with `tsc --noEmit` (paste into a TS project)
- [ ] Verify Python boundary test skeleton runs with `pytest` (paste into a Python project)
- [ ] Verify CI template YAML is valid (`yamllint` or paste into GitHub Actions editor)
- [ ] Verify all `Read references/*.md` directives in SKILL.md point to existing files
- [ ] Verify README and README_CN file trees match SKILL.md target structure

🤖 Generated with [Claude Code](https://claude.ai/code)