### PR TITLE
Add marketplace.json to fix plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "harness-init",
+  "owner": {
+    "name": "Gizele1",
+    "url": "https://github.com/Gizele1/harness-init"
+  },
+  "plugins": [
+    {
+      "name": "harness-init",
+      "description": "Makes a repo agent-ready: AGENTS.md, boundary tests, CI pipeline, GC scripts — based on OpenAI's harness engineering methodology",
+      "version": "1.1.0",
+      "author": {
+        "name": "Gizele1"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/Gizele1/harness-init",
+      "tags": ["agent", "scaffold", "ci", "boundary-tests", "architecture", "harness-engineering"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so the repo can be registered as a Claude Code marketplace
- Without this file, `claude plugin marketplace add` and `extraKnownMarketplaces` in `settings.json` both fail
- Validated with `claude plugin validate` — passes successfully

Fixes #26

## Test plan
- [ ] Run `claude plugin marketplace add https://github.com/Gizele1/harness-init.git` — should succeed
- [ ] Run `claude plugin install harness-init@harness-init` — should install the skill
- [ ] Verify `/harness-init` command is available after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)